### PR TITLE
setup.py should not require package

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -15,6 +15,9 @@ TMP_FILE=`mktemp /tmp/config.XXXXXXXXXX`
 sed -E "s/^(__version__ = ')[0-9]+\.[0-9]+\.[0-9]+(')$/\1$version\2/" flake8_commas.py > $TMP_FILE
 mv $TMP_FILE flake8_commas.py
 
+sed -E "s/(version=')[0-9]+\.[0-9]+\.[0-9]+(',)$/\1$version\2/" setup.py > $TMP_FILE
+mv $TMP_FILE setup.py
+
 # Verify our version made it into the file
 if ! grep "$version" flake8_commas.py &> /dev/null; then
   echo "Expected \`__version__\` to update via \`sed\` but it didn't" 1>&2

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import io
 from setuptools import setup
-import flake8_commas
 
 
 def read(*filenames, **kwargs):
@@ -19,7 +18,7 @@ long_description = read('README.rst')
 setup(
     name='flake8-commas',
     author='Trevor Creech',
-    version=flake8_commas.__version__,
+    version='0.1.1',
     install_requires=[
         'setuptools',
     ],


### PR DESCRIPTION
When I prepared requirements file:

```
# flake8
flake8==2.5.4
mccabe==0.4.0
pep8==1.7.0
pyflakes==1.0.0

# flake8 extensions
flake8-blind-except==0.1.0
flake8-debugger==1.4.0
flake8-pep257==1.0.5
flake8-print==2.0.1
flake8-quotes==0.1.2
flake8-string-format==0.2.1
flake8-commas==0.1.1
flake8-import-order==0.6.1
flake8-pep3101==0.2
pep8-naming==0.3.3
```

Then run `pip install -r../requirements.dev.txt`

And got this:

```
Collecting flake8-commas==0.1.1 (from -r ../requirements.txt (line 55))
  Using cached flake8-commas-0.1.1.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-VIomAr/flake8-commas/setup.py", line 3, in <module>
        import flake8_commas
      File "/tmp/pip-build-VIomAr/flake8-commas/flake8_commas.py", line 3, in <module>
        import pep8
    ImportError: No module named pep8
```

I think it's better to update version in `setup.py` in similar way as in `flake8_commas.py`.

Hope to see the new version (0.1.2) soon (:
Thanks for extension!