### PR TITLE
Fix for multi-line list/dict comprehensions

### DIFF
--- a/flake8_commas.py
+++ b/flake8_commas.py
@@ -13,6 +13,12 @@ class CommaChecker(object):
     name = __name__
     version = __version__
 
+    OPENING_BRACKETS = [
+        '[',
+        '{',
+        '(',
+    ]
+
     CLOSING_BRACKETS = [
         ']',
         '}',
@@ -50,13 +56,21 @@ class CommaChecker(object):
 
         last_last_token = None
         last_token = None
+        is_comprehension = [False]
         for token in tokens:
             if token.type == tokenize.COMMENT:
                 continue
 
+            if token.string in self.OPENING_BRACKETS:
+                is_comprehension.append(False)
+
+            if token.string == 'for' and token.type == tokenize.NAME:
+                is_comprehension[-1] = True
+
             if (token.string in self.CLOSING_BRACKETS and
                     last_token and last_token.type == tokenize.NL and
-                    last_last_token and last_last_token.string != ','):
+                    last_last_token and last_last_token.string != ',' and
+                    not is_comprehension[-1]):
 
                 end_row, end_col = last_last_token.end
                 yield {
@@ -64,6 +78,9 @@ class CommaChecker(object):
                     'line': end_row,
                     'col': end_col,
                 }
+
+            if token.string in self.CLOSING_BRACKETS:
+                is_comprehension.pop()
 
             last_last_token = last_token
             last_token = token

--- a/test/data/dict_comprehension.py
+++ b/test/data/dict_comprehension.py
@@ -1,0 +1,4 @@
+not_a_dict = {
+    x: y
+    for x, y in ((1, 2), (3, 4))
+}

--- a/test/data/list_comprehension.py
+++ b/test/data/list_comprehension.py
@@ -1,0 +1,4 @@
+not_a_list = [
+    s.strip()
+    for s in 'foo, bar, baz'.split(',')
+]

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -40,6 +40,14 @@ class CommaTestChecks(TestCase):
         comma_checker = CommaChecker(None, filename=get_absolute_path('data/comment_good_dict.py'))
         self.assertEqual(list(comma_checker.get_comma_errors(comma_checker.get_file_contents())), [])
 
+    def test_no_comma_required_list_comprehension(self):
+        comma_checker = CommaChecker(None, filename=get_absolute_path('data/list_comprehension.py'))
+        self.assertEqual(list(comma_checker.get_comma_errors(comma_checker.get_file_contents())), [])
+
+    def test_no_comma_required_dict_comprehension(self):
+        comma_checker = CommaChecker(None, filename=get_absolute_path('data/dict_comprehension.py'))
+        self.assertEqual(list(comma_checker.get_comma_errors(comma_checker.get_file_contents())), [])
+
 
 def get_absolute_path(filepath):
     return os.path.join(os.path.dirname(__file__), filepath)


### PR DESCRIPTION
I've added support for identifying multi-line list and dict comprehensions.

This is implemented with a simple stack to track the current bracket context and whether that is for a list/dict comprehension (identified with the `for` token), which means that it still identifies missing trailing commas in non-comprehension structures that are within comprehensions.

This fixes https://github.com/zedlander/flake8-commas/issues/3