### PR TITLE
Fix kwargs

### DIFF
--- a/flake8_commas.py
+++ b/flake8_commas.py
@@ -47,27 +47,20 @@ class CommaChecker(object):
 
     def get_comma_errors(self, file_contents):
         tokens = [Token(t) for t in tokenize.generate_tokens(lambda L=iter(file_contents): next(L))]
+        tokens = [t for t in tokens if t.type != tokenize.COMMENT]
 
-        last_last_token = None
-        last_token = None
-        for token in tokens:
-            if token.type == tokenize.COMMENT:
-                continue
-
+        for idx, token in enumerate(tokens):
             if (token.string in self.CLOSING_BRACKETS and
-                    last_token and last_token.type == tokenize.NL and
-                    last_last_token and last_last_token.string != ',' and
-                    last_last_token.string != 'kwargs'):
+                    (idx - 1 > 0) and tokens[idx - 1].type == tokenize.NL and
+                    (idx - 2 > 0) and tokens[idx - 2].string != ',' and
+                    (idx - 3 > 0) and tokens[idx - 3].string != '**'):
 
-                end_row, end_col = last_last_token.end
+                end_row, end_col = tokens[idx - 2].end
                 yield {
                     'message': '%s %s' % (COMMA_ERROR_CODE, COMMA_ERROR_MESSAGE),
                     'line': end_row,
                     'col': end_col,
                 }
-
-            last_last_token = last_token
-            last_token = token
 
 
 class Token:

--- a/flake8_commas.py
+++ b/flake8_commas.py
@@ -56,7 +56,8 @@ class CommaChecker(object):
 
             if (token.string in self.CLOSING_BRACKETS and
                     last_token and last_token.type == tokenize.NL and
-                    last_last_token and last_last_token.string != ','):
+                    last_last_token and last_last_token.string != ',' and
+                    last_last_token.string != 'kwargs'):
 
                 end_row, end_col = last_last_token.end
                 yield {

--- a/test/data/kwargs.py
+++ b/test/data/kwargs.py
@@ -3,3 +3,9 @@ result = function(
     bar,
     **kwargs
 )
+
+result = function(
+    foo,
+    bar,
+    **not_called_kwargs
+)

--- a/test/data/kwargs.py
+++ b/test/data/kwargs.py
@@ -1,0 +1,5 @@
+result = function(
+    foo,
+    bar,
+    **kwargs
+)

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -40,6 +40,10 @@ class CommaTestChecks(TestCase):
         comma_checker = CommaChecker(None, filename=get_absolute_path('data/comment_good_dict.py'))
         self.assertEqual(list(comma_checker.get_comma_errors(comma_checker.get_file_contents())), [])
 
+    def test_no_comma_required_after_kwargs(self):
+        comma_checker = CommaChecker(None, filename=get_absolute_path('data/kwargs.py'))
+        self.assertEqual(list(comma_checker.get_comma_errors(comma_checker.get_file_contents())), [])
+
 
 def get_absolute_path(filepath):
     return os.path.join(os.path.dirname(__file__), filepath)


### PR DESCRIPTION
The following is invalid python:

```python
x = function_call(
    foo,
    **kwargs,
)
```

Specifically, the comma after kwargs is not allowed. This change removes the warning for it.

**Edit:** after a bit of investigation, I've realised that of course nothing requires the "kwargs" to be called "kwargs". To support arbitrary names, I've jumped back another token to inspect the `**`, but this was going to get awkward, so I've refactored it to check slightly differently - see the commit message on 6e31094 for more details.